### PR TITLE
Correct some examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ Example
       | awk '{print $NF}')"
 
     _generate_long_lists \
-    | while read _line; do
+    | while IFS= read -r  _line; do
         _do_something_fun
       done
 
@@ -148,7 +148,7 @@ This variable can be used only *ONCE* in the sub-`{shell,process}`
 followed the pipe. Be sure you catch it up!
 
     echo test | fail_command | something_else
-    local _ret_pipe=( ${PIPESTATUS[@]} )
+    local _ret_pipe=( "${PIPESTATUS[@]}" )
     # from here, `PIPESTATUS` is not available anymore
 
 When this `_ret_pipe` array contains something other than zero,


### PR DESCRIPTION
- Make `while read` read the whole line correctly
- Fix missing double quote

Since when _This is a set of Bash coding conventions and good practices._, we shouldn't leave any _bad_ practice in our examples.

This pull fix two common shell scripters mistakes:
- Assume `read` builtin reads the whole line
- Missing double quote around variables

PS: IMHO, we should add another notice, about [using while loop in shell script considered bad practice](http://unix.stackexchange.com/q/169716/38906)
